### PR TITLE
Fix log line breaks in CI

### DIFF
--- a/poetry_multiverse_plugin/cli/utils.py
+++ b/poetry_multiverse_plugin/cli/utils.py
@@ -1,0 +1,13 @@
+from cleo.io.outputs.output import Output
+from cleo.io.outputs.section_output import SectionOutput
+
+
+def can_overwrite(output: Output) -> bool:
+    return output.is_decorated() and not output.is_debug()
+
+
+def overwrite(output: Output, message: str):
+    if isinstance(output, SectionOutput):
+        output.overwrite(message)
+    else:
+        output.write_line(message.strip())

--- a/poetry_multiverse_plugin/commands/workspace.py
+++ b/poetry_multiverse_plugin/commands/workspace.py
@@ -31,7 +31,7 @@ class CliUtils:
         try:
             io_thread.start()
             yield WorkspaceStatus(
-                OutputQueue(q.put, self.io.section),
+                OutputQueue(q.put, self.io),
                 self.workspace.projects,
                 StatusConfig(header, StatusConfig.default_template(action))
             )


### PR DESCRIPTION
WorkspaceStatus uses the main IO output in CI.
Line breaks are enforced when writing log lines.