### PR TITLE
Allow workspace commands outside of project

### DIFF
--- a/poetry_multiverse_plugin/commands/info.py
+++ b/poetry_multiverse_plugin/commands/info.py
@@ -10,7 +10,6 @@ class InfoCommand(WorkspaceCommand):
     description = 'Describe the multiverse workspace.'
 
     def handle_workspace(self, workspace: Workspace) -> int:
-        root = workspace.root
         projects = sorted(workspace.projects, key=lambda p: p.package.name)
 
         def format_row(project: Poetry) -> List[str]:
@@ -20,7 +19,7 @@ class InfoCommand(WorkspaceCommand):
             ]
 
         self.table(style='compact') \
-            .set_headers([f'{root.package.name}', str(workspace.config.root)]) \
+            .set_headers(['Workspace', str(workspace.config.root)]) \
             .set_rows([format_row(project) for project in projects]) \
             .render()
         return 0

--- a/poetry_multiverse_plugin/commands/lock.py
+++ b/poetry_multiverse_plugin/commands/lock.py
@@ -30,9 +30,9 @@ multiple projects are locked to the same version.
         root = workspace.root
 
         with self.cli.progress('Locking workspace...'):
-            pool = locked_pool(list(workspace.packages)) if self.option('no-update', True) else \
+            pool = locked_pool(list(workspace.packages)) if self.option('no-update') else \
                 workspace_pool(*workspace.projects)
-            return_code = lock(root, pool, env=self.env)
+            return_code = lock(root, pool)
             if return_code != 0:
                 self.io.write_error_line('<error>Failed to lock workspace!</>')
                 return return_code
@@ -42,7 +42,7 @@ multiple projects are locked to the same version.
 
             def run(project: Poetry) -> int:
                 status(project).update('Locking...')
-                return lock(project, workspace_locked_pool, env=self.env)
+                return lock(project, workspace_locked_pool)
 
             with ThreadPoolExecutor() as executor:
                 jobs = {

--- a/poetry_multiverse_plugin/commands/show.py
+++ b/poetry_multiverse_plugin/commands/show.py
@@ -1,24 +1,50 @@
-from poetry.console.commands import show
+from pathlib import Path
+from typing import Optional
 
+from poetry.console.commands import show
+from poetry.puzzle.exceptions import SolverProblemError
+from poetry.utils.env.null_env import NullEnv
+
+from poetry_multiverse_plugin.commands.workspace import WorkspaceCommand
+from poetry_multiverse_plugin.config import WorkspaceConfiguration
 from poetry_multiverse_plugin.repositories import lock, locked_pool
 from poetry_multiverse_plugin.workspace import Workspace
 
 
-class ShowCommand(show.ShowCommand):
+class ShowCommand(WorkspaceCommand):
     name = 'workspace show'
     description = 'List dependencies in the multiverse workspace.'
 
+    arguments = show.ShowCommand.arguments
+    options = show.ShowCommand.options
+    aliases = show.ShowCommand.aliases
+    usages = show.ShowCommand.usages
+    commands = show.ShowCommand.commands
+
+    def _workspace(self) -> Optional[Workspace]:
+        path = self.io.input.option('directory')
+        if config := WorkspaceConfiguration.find(Path(path) if path else Path.cwd()):
+            return Workspace(config)
+        return None
+
     def handle(self) -> int:
-        workspace = Workspace.create(self.poetry)
+        workspace = self._workspace()
         if not workspace:
             self.io.write_error('Unable to locate workspace root')
             return 1
 
         root = workspace.root
-        return_code = lock(root, locked_pool(list(workspace.packages)), env=self.env)
-        if return_code != 0:
+        try:
+            return_code = lock(root, locked_pool(list(workspace.packages)))
+            if return_code != 0:
                 self.io.write_error_line('<error>Failed to lock workspace!</>')
                 return return_code
+        except SolverProblemError:
+            self.io.write_error_line('<error>Failed to lock workspace!</>')
+            return 1
 
-        self.set_poetry(root)
-        return super().handle()
+        show_command = show.ShowCommand()
+        show_command.set_application(self.application)
+        show_command.set_poetry(root)
+        show_command.set_env(NullEnv())
+        return show_command.run(self.io)

--- a/poetry_multiverse_plugin/hooks/lock.py
+++ b/poetry_multiverse_plugin/hooks/lock.py
@@ -6,7 +6,6 @@ from poetry.console.commands.command import Command
 from poetry.console.commands.installer_command import InstallerCommand
 from poetry.console.commands.lock import LockCommand
 from poetry.poetry import Poetry
-from poetry.utils.env.null_env import NullEnv
 
 from poetry_multiverse_plugin.cli.progress import progress
 from poetry_multiverse_plugin.hooks.hook import Hook
@@ -47,15 +46,13 @@ class PreLockHook(Hook):
             return
 
         root = workspace.root
-        root_env = NullEnv(command.env.path, command.env.base)
         with progress(io, 'Preparing workspace...'):
-            lock(root, locked_pool(list(workspace.packages)), env=root_env)
+            lock(root, locked_pool(list(workspace.packages)))
 
         root.set_pool(workspace_pool(*workspace.projects, locked=root))
         command.set_installer(create_installer(
             root,
-            root.pool,
-            env=root_env
+            root.pool
         ))
         with poetry_target(root, command) as cmd:
             with no_install(io) as lock_io:

--- a/poetry_multiverse_plugin/repositories.py
+++ b/poetry_multiverse_plugin/repositories.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+from contextlib import contextmanager
+from typing import Iterator, List, Optional
 
 from cleo.io.io import IO
 from cleo.io.null_io import NullIO
@@ -10,6 +11,10 @@ from poetry.poetry import Poetry
 from poetry.repositories.repository import Repository
 from poetry.repositories.repository_pool import Priority, RepositoryPool
 from poetry.utils.env import Env
+from poetry.utils.env.null_env import NullEnv
+
+from poetry_multiverse_plugin.utils import Singleton
+
 
 class LockedRepository(Repository):
     def __init__(self, parent: LockfileRepository, pool: RepositoryPool) -> None:
@@ -51,12 +56,12 @@ def project_pool(*projects: Poetry, locked: Poetry) -> RepositoryPool:
 def create_installer(
     project: Poetry, 
     pool: RepositoryPool, *,
-    env: Env,
+    env: Optional[Env] = None,
     io: Optional[IO] = None
 ) -> Installer:
     return Installer(
         io or NullIO(),
-        env,
+        env or NullEnv(),
         project.package,
         project.locker,
         pool,
@@ -65,5 +70,22 @@ def create_installer(
     )
 
 
-def lock(project: Poetry, pool: RepositoryPool, *, env: Env) -> int:
+def lock(project: Poetry, pool: RepositoryPool, *, env: Optional[Env] = None) -> int:
     return create_installer(project, pool, env=env).lock().run()
+
+
+class PoolFactory(metaclass=Singleton):
+    def __init__(self, pool: Optional[RepositoryPool] = None):
+        self._pool = pool
+
+    def get(self) -> Optional[RepositoryPool]:
+        return self._pool
+    
+    @contextmanager
+    def override(self, pool: RepositoryPool) -> Iterator[RepositoryPool]:
+        old_pool = self._pool
+        try:
+            self._pool = pool
+            yield pool
+        finally:
+            self._pool = old_pool

--- a/poetry_multiverse_plugin/root.py
+++ b/poetry_multiverse_plugin/root.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from poetry.config.config import Config
 from poetry.core.constraints.version.parser import parse_single_constraint
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.packages.locker import Locker
@@ -9,8 +10,9 @@ from poetry.factory import Factory
 from poetry_multiverse_plugin.dependencies import Dependencies
 
 
-def root_project(*projects: Poetry, path: Path, context: Poetry) -> Poetry:
+def root_project(*projects: Poetry, path: Path) -> Poetry:
     aggregate_project = ProjectPackage('workspace', '0.0.0')
+    local_config = {}
 
     py_versions = parse_single_constraint('*')
     for project in projects:
@@ -24,9 +26,8 @@ def root_project(*projects: Poetry, path: Path, context: Poetry) -> Poetry:
     pyproject.write_text(Factory.create_pyproject_from_package(aggregate_project).as_string())
     return Poetry(
         file=pyproject,
-        local_config=context.local_config,
+        local_config=local_config,
         package=aggregate_project,
-        locker=Locker(path / 'workspace.lock', context.local_config),
-        config=context.config,
-        disable_cache=context.disable_cache
+        locker=Locker(path / 'workspace.lock', local_config),
+        config=Config.create()
     )

--- a/poetry_multiverse_plugin/utils.py
+++ b/poetry_multiverse_plugin/utils.py
@@ -1,0 +1,6 @@
+class Singleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/poetry_multiverse_plugin/workspace.py
+++ b/poetry_multiverse_plugin/workspace.py
@@ -5,41 +5,34 @@ from typing import Iterable, Mapping, Optional
 
 from poetry.factory import Factory
 from poetry.poetry import Poetry
-from poetry.repositories.repository_pool import RepositoryPool
 
 from poetry_multiverse_plugin.config import WorkspaceConfiguration
 from poetry_multiverse_plugin.dependencies import Dependencies
 from poetry_multiverse_plugin.packages import Packages
+from poetry_multiverse_plugin.repositories import PoolFactory
 from poetry_multiverse_plugin.root import root_project
 
 
 class Workspace:
     def __init__(
         self,
-        config: WorkspaceConfiguration,
-        context: Poetry, *,
-        disable_cache: bool = False,
-        pool: Optional[RepositoryPool] = None
+        config: WorkspaceConfiguration, *,
+        disable_cache: bool = False
     ) -> None:
         self.config = config
-        self.context = context
         self.disable_cache = disable_cache
-        self.pool = pool
         self.root_project = TemporaryDirectory()
 
     @staticmethod
     def create(
         poetry: Poetry, *,
-        pool: Optional[RepositoryPool] = None, 
         env: Mapping[str, str] = os.environ
     ) -> Optional['Workspace']:
         if config := WorkspaceConfiguration.find(poetry.pyproject_path.parent, env):
             if poetry.pyproject_path.parent in config.project_dirs:
                 return Workspace(
                     config,
-                    poetry,
-                    disable_cache=poetry.disable_cache,
-                    pool=pool
+                    disable_cache=poetry.disable_cache
                 )
             return None
     
@@ -47,10 +40,9 @@ class Workspace:
     def root(self) -> Poetry:
         project = root_project(
             *self.projects,
-            path=Path(self.root_project.name),
-            context=self.context
+            path=Path(self.root_project.name)
         )
-        if pool := self.pool:
+        if pool := PoolFactory().get():
             project.set_pool(pool)
         return project
     
@@ -64,7 +56,7 @@ class Workspace:
                     project,
                     disable_cache=self.disable_cache
                 )
-                if pool := self.pool:
+                if pool := PoolFactory().get():
                     project.set_pool(pool)
                 yield project
             except RuntimeError:

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -1,0 +1,45 @@
+from poetry.core.packages.package import Package
+
+from poetry_multiverse_plugin.commands.show import ShowCommand
+from tests import utils
+from tests.conftest import ProjectFactory
+
+
+def test_show_no_workspace(project: ProjectFactory):
+    project.packages(Package('click', '8.1.2'))
+    p1 = utils.add(project('p1'), 'click=^8.1')
+
+    show = utils.command(p1, ShowCommand)
+    assert show.execute() == 1
+
+    output = show.io.fetch_error()
+    assert 'workspace root' in output
+
+
+def test_show(project: ProjectFactory):
+    project.packages(Package('click', '8.1.2'))
+    p1 = utils.add(project('p1'), 'click=^8.1')
+
+    project.workspace(p1)
+    show = utils.command(p1, ShowCommand)
+    assert show.execute() == 0
+
+    output = show.io.fetch_output()
+    assert 'click' in output
+    assert '8.1.2' in output
+
+
+def test_show_conflict(project: ProjectFactory):
+    project.packages(
+        Package('click', '7.0.9'),
+        Package('click', '8.1.2')
+    )
+    p1 = utils.add(project('p1'), 'click=^7')
+    utils.add(project('p2'), 'click=^8')
+
+    project.workspace(p1)
+    show = utils.command(p1, ShowCommand)
+    assert show.execute() == 1
+
+    output = show.io.fetch_error()
+    assert 'Failed to lock workspace' in output

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import List, Optional, Type
 
+from cleo.commands.command import Command as CleoCommand
 from cleo.events.console_command_event import ConsoleCommandEvent
 from cleo.events.event import Event
 from cleo.events.event_dispatcher import EventDispatcher
@@ -17,7 +18,7 @@ from poetry.repositories import RepositoryPool
 from poetry.utils.env.mock_env import MockEnv
 
 
-def set_env(command: Command):
+def set_env(command: CleoCommand):
     if not isinstance(command, EnvCommand) or isinstance(command, SelfCommand):
         return
     if command._env is not None:
@@ -49,8 +50,8 @@ class MockApplication(Application):
 
 def command(
     poetry: Poetry,
-    factory: Type[Command], *,
-    deps: Optional[List[Type[Command]]] = None
+    factory: Type[CleoCommand], *,
+    deps: Optional[List[Type[CleoCommand]]] = None
 ) -> CommandTester:
     app = MockApplication(poetry)
     for dep in deps or []:
@@ -61,7 +62,8 @@ def command(
     set_env(cmd)
     if isinstance(cmd, InstallerCommand):
         Application.configure_installer_for_command(cmd, tester.io)
-    cmd.set_poetry(poetry)
+    if isinstance(cmd, Command):
+        cmd.set_poetry(poetry)
     return tester
 
 


### PR DESCRIPTION
Ensures commands can be run in workspace root, even if there's no Poetry project in the working directory.